### PR TITLE
Fixed issue with parsing consecutive script or style tags.

### DIFF
--- a/htmlparser.js
+++ b/htmlparser.js
@@ -109,7 +109,7 @@
 				}
 
 			} else {
-				html = html.replace(new RegExp("(.*)<\/" + stack.last() + "[^>]*>"), function (all, text) {
+				html = html.replace(new RegExp("(.*?)<\/" + stack.last() + "[^>]*>"), function (all, text) {
 					text = text.replace(/<!--(.*?)-->/g, "$1")
 						.replace(/<!\[CDATA\[(.*?)]]>/g, "$1");
 


### PR DESCRIPTION
Made matching of contents insider `<script>` and `<style>` non-hungry. Previously

``` html
<script>var a;</script><script>var b;</script>
```

would get parsed as

```
<script>
   "var a;</script><script>var b;"
</script>
```

Thanks for the awesome library.

P.S. do you plan on adding unit tests?
