### PR TITLE
Updated HTML5 void tags.

### DIFF
--- a/htmlparser.js
+++ b/htmlparser.js
@@ -36,7 +36,7 @@
 		attr = /([a-zA-Z_:][-a-zA-Z0-9_:.]+)(?:\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))?/g;
 
 	// Empty Elements - HTML 5
-	var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed");
+	var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,link,meta,param,embed,command,keygen,source,track,wbr");
 
 	// Block Elements - HTML 5
 	var block = makeMap("address,article,applet,aside,audio,blockquote,button,canvas,center,dd,del,dir,div,dl,dt,fieldset,figcaption,figure,footer,form,frameset,h1,h2,h3,h4,h5,h6,header,hgroup,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,output,p,pre,section,script,table,tbody,td,tfoot,th,thead,tr,ul,video");


### PR DESCRIPTION
Void tags taken from http://www.w3.org/TR/html-markup/syntax.html#syntax-elements.
Removed isindex tag as it was deprecated since HTML 4.01 (source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/isindex).
